### PR TITLE
Fix cmake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ pkg_check_modules(SDL2 REQUIRED sdl2)
 target_link_libraries (good_robot ${SDL2_LIBRARIES})
 include_directories (${SDL2_INCLUDE_DIRS})
 
+set(OpenGL_GL_PREFERENCE "GLVND")
 find_package(OpenGL REQUIRED)
 target_link_libraries (good_robot ${OPENGL_LIBRARIES})
 include_directories (${OPENGL_INCLUDE_DIR})

--- a/steamworks/FindSTEAMWORKS.cmake
+++ b/steamworks/FindSTEAMWORKS.cmake
@@ -42,7 +42,7 @@ else()
 	endif()
 endif()
 
-find_package_handle_standard_args(Steamworks
+find_package_handle_standard_args(STEAMWORKS
 	DEFAULT_MSG
 	STEAMWORKS_LIBRARY
 	STEAMWORKS_INCLUDE_DIR


### PR DESCRIPTION
This patch fixes the following warnings:
```
CMake Warning (dev) at /usr/share/cmake-3.18/Modules/FindOpenGL.cmake:305 (message):
  Policy CMP0072 is not set: FindOpenGL prefers GLVND by default when
  available.  Run "cmake --help-policy CMP0072" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  FindOpenGL found both a legacy GL library:

    OPENGL_gl_LIBRARY: /usr/lib/libGL.so

  and GLVND libraries for OpenGL and GLX:

    OPENGL_opengl_LIBRARY: /usr/lib/libOpenGL.so
    OPENGL_glx_LIBRARY: /usr/lib/libGLX.so

  OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for
  compatibility with CMake 3.10 and below the legacy GL library will be used.
Call Stack (most recent call first):
  CMakeLists.txt:37 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
and
```
CMake Warning (dev) at /usr/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:273 (message):
  The package name passed to `find_package_handle_standard_args` (Steamworks)
  does not match the name of the calling package (STEAMWORKS).  This can lead
  to problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  steamworks/FindSTEAMWORKS.cmake:45 (find_package_handle_standard_args)
  CMakeLists.txt:69 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```